### PR TITLE
Add named profiles for multi-account credential isolation

### DIFF
--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -10,6 +10,7 @@ import { loadCredentials } from "./client.js";
 import { log } from "../utils/logging.js";
 import { mapGoogleError } from "../errors/index.js";
 import { getScopesForEnabledServices } from "../config/scopes.js";
+import { getActiveProfile } from "./utils.js";
 import {
   renderSuccessPage,
   renderErrorPage,
@@ -116,8 +117,9 @@ export class AuthServer {
       const credentialsDir = path.basename(path.dirname(tokenPath));
       const gitignoreWarning = isProjectLevel ? buildGitignoreWarning(credentialsDir) : "";
 
+      const activeProfile = getActiveProfile();
       res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(renderSuccessPage(tokenPath, gitignoreWarning));
+      res.end(renderSuccessPage(tokenPath, gitignoreWarning, activeProfile));
     } catch (error: unknown) {
       this.authCompletedSuccessfully = false;
       this.clearPkceState();

--- a/src/auth/templates.ts
+++ b/src/auth/templates.ts
@@ -84,7 +84,12 @@ const CSRF_ERROR_STYLES = `
 /**
  * Render the success page after OAuth completion.
  */
-export function renderSuccessPage(tokenPath: string, gitignoreWarning: string): string {
+export function renderSuccessPage(
+  tokenPath: string,
+  gitignoreWarning: string,
+  profileName: string | null = null,
+): string {
+  const profileLine = profileName ? `<p>Profile: <code>${escapeHtml(profileName)}</code></p>` : "";
   return `
     <!DOCTYPE html>
     <html lang="en">
@@ -96,7 +101,7 @@ export function renderSuccessPage(tokenPath: string, gitignoreWarning: string): 
     </head>
     <body>
       <div class="container">
-        <h1>Authentication Successful!</h1>
+        <h1>Authentication Successful!</h1>${profileLine}
         <p>Your authentication tokens have been saved successfully to:</p>
         <p><code>${escapeHtml(tokenPath)}</code></p>${gitignoreWarning}
         <p style="margin-top: 1em;">You can now close this browser window.</p>

--- a/src/schemas/status.ts
+++ b/src/schemas/status.ts
@@ -1,24 +1,8 @@
 import { z } from "zod";
 
 /**
- * Schema for get_status tool - consolidated health, auth status, and diagnostics.
+ * Schema for get_status tool - returns full health, auth, and diagnostics.
  */
-export const GetStatusSchema = z
-  .object({
-    diagnose: z
-      .boolean()
-      .optional()
-      .default(false)
-      .describe("Run full diagnostic with API validation and recommendations"),
-    validate_with_api: z
-      .boolean()
-      .optional()
-      .default(false)
-      .describe("Validate tokens with actual API call (requires diagnose: true)"),
-  })
-  .refine((data) => !data.validate_with_api || data.diagnose, {
-    message: "validate_with_api requires diagnose to be true",
-    path: ["validate_with_api"],
-  });
+export const GetStatusSchema = z.object({});
 
 export type GetStatusInput = z.infer<typeof GetStatusSchema>;

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -3712,22 +3712,11 @@ export const discoveryTools: ToolDefinition[] = [
   {
     name: "get_status",
     description:
-      "Get server status including health, authentication, and enabled services. " +
-      "Use diagnose=true for full diagnostic with actionable recommendations.",
+      "Get server health, authentication status, connected account, " +
+      "and diagnostics with actionable recommendations.",
     inputSchema: {
       type: "object",
-      properties: {
-        diagnose: {
-          type: "boolean",
-          description: "Run full diagnostic with recommendations (default: false)",
-          default: false,
-        },
-        validate_with_api: {
-          type: "boolean",
-          description: "Validate with API call when diagnose=true (default: false)",
-          default: false,
-        },
-      },
+      properties: {},
     },
     outputSchema: {
       type: "object",
@@ -3740,6 +3729,10 @@ export const discoveryTools: ToolDefinition[] = [
         version: { type: "string", description: "Server version" },
         uptime_seconds: { type: "number", description: "Server uptime in seconds" },
         timestamp: { type: "string", description: "ISO 8601 timestamp" },
+        profile: {
+          type: ["string", "null"],
+          description: "Active named profile, or null if using default",
+        },
         auth: {
           type: "object",
           description: "Authentication status",
@@ -3772,7 +3765,7 @@ export const discoveryTools: ToolDefinition[] = [
         },
         config_checks: {
           type: "array",
-          description: "Configuration checks (only when diagnose=true)",
+          description: "Configuration checks with fix steps",
           items: {
             type: "object",
             properties: {
@@ -3789,7 +3782,7 @@ export const discoveryTools: ToolDefinition[] = [
         },
         token_check: {
           type: "object",
-          description: "Detailed token info (only when diagnose=true)",
+          description: "Detailed token info",
           properties: {
             has_access_token: { type: "boolean" },
             has_refresh_token: { type: "boolean" },
@@ -3800,7 +3793,7 @@ export const discoveryTools: ToolDefinition[] = [
         },
         last_error: {
           type: "object",
-          description: "Last auth error (only when diagnose=true)",
+          description: "Last auth error, if any",
           properties: {
             code: { type: "string", description: "Error code" },
             reason: { type: "string", description: "Error reason" },
@@ -3809,7 +3802,7 @@ export const discoveryTools: ToolDefinition[] = [
         },
         api_validation: {
           type: "object",
-          description: "API validation result (only when validate_with_api=true)",
+          description: "API validation result",
           properties: {
             success: { type: "boolean" },
             user_email: { type: "string", description: "Authenticated user email if successful" },
@@ -3818,7 +3811,7 @@ export const discoveryTools: ToolDefinition[] = [
         },
         recommendations: {
           type: "array",
-          description: "Actionable recommendations (only when diagnose=true)",
+          description: "Actionable recommendations",
           items: { type: "string" },
         },
       },


### PR DESCRIPTION
## Summary

- Add `GOOGLE_WORKSPACE_MCP_PROFILE` env var and `--profile` CLI flag to isolate credentials/tokens per Google account
- Each profile resolves to `~/.config/google-workspace-mcp/profiles/{name}/` with separate `tokens.json` and `credentials.json`
- Priority chain: explicit env var > legacy env var > profile > XDG default (fully backward compatible)
- Simplify `get_status` by removing `diagnose`/`validate_with_api` flags — always returns full diagnostics
- Profile name validation via allowlist regex prevents path traversal and injection
- Profile exposed in `get_status` response (both structured data and text summary) and on OAuth success page

### Usage

```bash
# Auth each profile once
npx @dguido/google-workspace-mcp auth --profile personal
npx @dguido/google-workspace-mcp auth --profile work

# Configure per-project in MCP client config
{ "env": { "GOOGLE_WORKSPACE_MCP_PROFILE": "personal" } }
```

### Files changed

| File | Change |
|------|--------|
| `src/auth/utils.ts` | `getActiveProfile()`, `getProfileDirectory()`, profile priority in path functions, XDG dedup |
| `src/auth/utils.test.ts` | 15 new tests for profiles (validation, priority chain, edge cases) |
| `src/index.ts` | `--profile` CLI flag, help text, startup logging |
| `src/handlers/status.ts` | Profile in status response, removed diagnose/validate_with_api |
| `src/handlers/status.test.ts` | Profile mock + tests, updated for simplified status |
| `src/schemas/status.ts` | Simplified schema (removed diagnose/validate_with_api) |
| `src/tools/definitions.ts` | `profile` field in outputSchema (`["string", "null"]`) |
| `src/auth/templates.ts` | Profile name on OAuth success page |
| `src/auth/server.ts` | Pass profile to success page |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 745 tests pass (15 new)
- [x] `npm run lint` — clean
- [x] Pre-commit hooks pass (format, lint, typecheck, test)
- [ ] Manual: `auth --profile test` saves tokens to `~/.config/google-workspace-mcp/profiles/test/`
- [ ] Manual: `get_status` shows `profile: "test"` when profile active, `profile: null` otherwise
- [ ] Manual: Explicit `--token-path` overrides profile path

🤖 Generated with [Claude Code](https://claude.com/claude-code)